### PR TITLE
chore: bump version to 1.0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "code2image",
-  "version": "1.0.8",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "code2image",
-      "version": "1.0.8",
+      "version": "1.0.10",
       "dependencies": {
         "@sensorario/sg-components": "^0.0.68",
         "highlight.js": "^11.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code2image",
-  "version": "1.0.8",
+  "version": "1.0.10",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Commit the version bump (1.0.8 → 1.0.10) produced by the deploy script's `npm version patch` build step across the two prior deploys, so `next` matches what's actually live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)